### PR TITLE
Remove npm install --global in test.sh

### DIFF
--- a/elm-create.sh
+++ b/elm-create.sh
@@ -2,15 +2,16 @@
 
 abs(){
     if [ -d "$1" ]; then
-        cd "$1"
+        cd "$1" 2> /dev/null
         echo "$(pwd -P)"
     else
-        cd "$(dirname "$1")"
+        cd "$(dirname "$1")" 2> /dev/null
         echo "$(pwd -P)/$(basename "$1")"
     fi
 }
 
-ELM_BOILERPLATE_DIR=$(abs $(dirname $(abs $0))/../lib/node_modules/elm-boilerplate)
+ELM_DEFAULT_BOILERPLATE_DIR=$(abs $(dirname $(abs $0))/../lib/node_modules/elm-boilerplate)
+: ${ELM_BOILERPLATE_DIR:=$ELM_DEFAULT_BOILERPLATE_DIR}
 
 error() {
   >&2 echo $*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elm-boilerplate",
   "version": "1.1.3",
-  "description": "A simple Makefile able to create Elm app",
+  "description": "A simple Makefile able to create a new Elm app",
   "scripts": {
     "test": "./test.sh"
   },

--- a/test.sh
+++ b/test.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env sh
-npm install -g .
-
 mkdir test-app && cd test-app || exit 1
 
-elm create test-app || exit 1
+ELM_BOILERPLATE_DIR=.. ../elm-create.sh test-app || exit 1
 elm test | grep "Running 1 test" || exit 1
 
 cd .. && rm -rf test-app


### PR DESCRIPTION
For this, I modified elm-create.sh and use shell parameter expansion to
allow mock ELM_BOILERPLATE_DIR environment variable.